### PR TITLE
Update for Bevy 0.10.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,14 @@ description = "Minimalistic implementation of entity kinds for Bevy ECS."
 homepage = "https://github.com/Zeenobit/bevy_kindly"
 repository = "https://github.com/Zeenobit/bevy_kindly"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_ecs = "0.8.*"
+bevy_ecs = "0.10.*"
 bevy_kindly_macros = "0.2.1"
 
 [dev-dependencies]
-bevy = "0.8.0"
+bevy = "0.10.*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ where
 
 ///
 /// A [`WorldQuery`] filter for entities with some given [`EntityKind`].
-/// 
+///
 /// Similar to [`With`] in usage.
 ///
 #[derive(WorldQuery)]
@@ -96,7 +96,7 @@ pub struct WithKind<T: EntityKind> {
 
 ///
 /// A [`WorldQuery`] filter for entities that were just given a new [`EntityKind`].
-/// 
+///
 /// Similar to [`Added`] in usage.
 ///
 #[derive(WorldQuery)]
@@ -106,7 +106,7 @@ pub struct AddedKind<T: EntityKind> {
 
 ///
 /// A [`WorldQuery`] used to query entities with some given [`EntityKind`].
-/// 
+///
 /// Similar to [`Entity`] in usage.
 ///
 #[derive(WorldQuery)]
@@ -219,7 +219,7 @@ impl<'w, 's, 'a> InsertKind<'w, 's, 'a> for EntityCommands<'w, 's, 'a> {
         mut self,
         bundle: T::Bundle,
     ) -> EntityKindCommands<'w, 's, 'a, T> {
-        self.insert_bundle(KindBundle::<T>::new(bundle));
+        self.insert(KindBundle::<T>::new(bundle));
         // SAFE: `KindBundle` was just inserted
         unsafe { EntityKindCommands::from_entity_unchecked(self) }
     }
@@ -246,7 +246,7 @@ impl<'w, 's, 'a> KindCommands<'w, 's, 'a> for &'a mut Commands<'w, 's> {
         self,
         bundle: T::Bundle,
     ) -> EntityKindCommands<'w, 's, 'a, T> {
-        self.spawn().insert_kind(bundle)
+        self.spawn_empty().insert_kind(bundle)
     }
 
     fn with_kind<T: EntityKind>(self, kind: &T) -> EntityKindCommands<'w, 's, 'a, T> {


### PR DESCRIPTION
Minor changes to maintain compatibility with Bevy 0.10.x (note: this bumps create release to 0.3.2).